### PR TITLE
Update .syncignore files to work

### DIFF
--- a/.github/.syncignore
+++ b/.github/.syncignore
@@ -1,0 +1,3 @@
+CODEOWNERS
+workflows/create-draft-release.yml
+workflows/push-buildpackage.yml

--- a/.github/workflows/.syncignore
+++ b/.github/workflows/.syncignore
@@ -1,1 +1,0 @@
-create-draft-release.yml

--- a/.gitignore
+++ b/.gitignore
@@ -17,4 +17,4 @@ linux/
 dependencies/
 package/
 scratch/
-
+.bin/


### PR DESCRIPTION
I believe this will fix the issue with synching, where it was not seeing the `.github/workflows/.syncignore` file. It only looks for the `.syncignore` file at the top level, not nested.
